### PR TITLE
Tag docker images with branch build

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -32,10 +32,12 @@ if ! docker pull "${image_name}:${image_tag}"; then
   if [ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]; then
     docker build . --file "${docker_file}" -t "${image_name}:${image_tag}" -t "${image_name}:latest" || exit 1
   else
-    docker build . --file "${docker_file}" -t "${image_name}" -t "branch-$BUILDKITE_BUILD_NUMBER" || exit 1
+    docker build . --file "${docker_file}" -t "${image_name}:${image_tag}" || exit 1
   fi
-  docker push "${image_name}"
 fi || echo "Not found"
+  
+docker tag "${image_name}" "branch-$BUILDKITE_BUILD_NUMBER"
+docker push "${image_name}"
 
 # Support using https://github.com/buildkite-plugins/docker-buildkite-plugin without an image
 export BUILDKITE_PLUGIN_DOCKER_IMAGE="${image_name}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -32,7 +32,7 @@ if ! docker pull "${image_name}:${image_tag}"; then
   if [ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]; then
     docker build . --file "${docker_file}" -t "${image_name}:${image_tag}" -t "${image_name}:latest" || exit 1
   else
-    docker build . --file "${docker_file}" -t "${image_name}" -t "$BUILDKITE_BUILD_NUMBER" || exit 1
+    docker build . --file "${docker_file}" -t "${image_name}" -t "branch-$BUILDKITE_BUILD_NUMBER" || exit 1
   fi
   docker push "${image_name}"
 fi || echo "Not found"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -10,29 +10,16 @@ get_ecr_url() {
     --query 'repositories[0].repositoryUri'
 }
 
-compute_tag() {
-  local docker_file="$1"
-  local sums=($(sha1sum "${docker_file}"))
-  while IFS='=' read -r name _ ; do
-    if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_CACHE_ON_[0-9]+) ]] ; then
-      local sha=($(sha1sum "${!name}"))
-      sums="${sums}${sha:-''}"
-    fi
-  done < <(env | sort)
-  echo "${sums}" | sha1sum | cut -c-7
-}
-
 $(aws ecr get-login --no-include-email)
 docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
 image_name="$(get_ecr_url ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME})"
-image_tag="$(compute_tag ${docker_file})"
 
-if ! docker pull "${image_name}:${image_tag}"; then
+if ! docker pull "${image_name}:$BUILD_VERSION"; then
   echo "Image not cached, building"
   if [ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]; then
-    docker build . --file "${docker_file}" -t "${image_name}:${image_tag}" -t "${image_name}:latest" || exit 1
+    docker build . --file "${docker_file}" -t "${image_name}:$BUILD_VERSION" -t "${image_name}:latest" || exit 1
   else
-    docker build . --file "${docker_file}" -t "${image_name}" || exit 1
+    docker build . --file "${docker_file}" -t "${image_name}:branch-$BUILD_VERSION" || exit 1
   fi
   docker push "${image_name}"
 fi || echo "Not found"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -32,7 +32,7 @@ if ! docker pull "${image_name}:${image_tag}"; then
   if [ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]; then
     docker build . --file "${docker_file}" -t "${image_name}:${image_tag}" -t "${image_name}:latest" || exit 1
   else
-    docker build . --file "${docker_file}" -t "${image_name}" -t "$BUILD_VERSION" || exit 1
+    docker build . --file "${docker_file}" -t "${image_name}" -t "$BUILDKITE_BUILD_NUMBER" || exit 1
   fi
   docker push "${image_name}"
 fi || echo "Not found"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -10,16 +10,29 @@ get_ecr_url() {
     --query 'repositories[0].repositoryUri'
 }
 
+compute_tag() {
+  local docker_file="$1"
+  local sums=($(sha1sum "${docker_file}"))
+  while IFS='=' read -r name _ ; do
+    if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_CACHE_ON_[0-9]+) ]] ; then
+      local sha=($(sha1sum "${!name}"))
+      sums="${sums}${sha:-''}"
+    fi
+  done < <(env | sort)
+  echo "${sums}" | sha1sum | cut -c-7
+}
+
 $(aws ecr get-login --no-include-email)
 docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
 image_name="$(get_ecr_url ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME})"
+image_tag="$(compute_tag ${docker_file})"
 
-if ! docker pull "${image_name}:$BUILD_VERSION"; then
+if ! docker pull "${image_name}:${image_tag}"; then
   echo "Image not cached, building"
   if [ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]; then
-    docker build . --file "${docker_file}" -t "${image_name}:$BUILD_VERSION" -t "${image_name}:latest" || exit 1
+    docker build . --file "${docker_file}" -t "${image_name}:${image_tag}" -t "${image_name}:latest" || exit 1
   else
-    docker build . --file "${docker_file}" -t "${image_name}:branch-$BUILD_VERSION" || exit 1
+    docker build . --file "${docker_file}" -t "${image_name}" -t "$BUILD_VERSION" || exit 1
   fi
   docker push "${image_name}"
 fi || echo "Not found"


### PR DESCRIPTION
## Purpose 
Tag docker images with buildkites build number instead of computing a sha as the tag. 

## Approach
To keep consistent with most current seek builds. Also easier to pull specific docker image if tag is known prior