### PR TITLE
Rework build args and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ steps:
             - any-$BUILDKITE_BUILD_NUMBER
 ```
 
+More complex branch workflows can be achieved by using multiple pipeline steps
+with differing `branches`:
+
+```yaml
+steps:
+  - branches: '!dev !prod'
+    plugins:
+      - seek-oss/docker-ecr-publish#v1.1.6:
+          args: BRANCH_TYPE=branch
+          ecr-name: my-repo
+          tags: branch-$BUILDKITE_BUILD_NUMBER
+  - branches: dev
+    plugins:
+      - seek-oss/docker-ecr-publish#v1.1.6:
+          args: BRANCH_TYPE=dev
+          ecr-name: my-repo
+          tags: dev-$BUILDKITE_BUILD_NUMBER
+  - branches: prod
+    plugins:
+      - seek-oss/docker-ecr-publish#v1.1.6:
+          args: BRANCH_TYPE=prod
+          ecr-name: my-repo
+          tags: prod-$BUILDKITE_BUILD_NUMBER
+```
+
 This plugin can be used in combination with the [Create
 ECR](https://github.com/seek-oss/create-ecr-buildkite-plugin) plugin to fully
 manage an ECR application repository within one pipeline step:

--- a/README.md
+++ b/README.md
@@ -173,9 +173,7 @@ steps:
 
 - `tags` (optional, array|string)
 
-  Tags to push on all builds. These are listed _before_ the branch-specific
-  `branch-tags` and `default-tags` properties in the resulting `docker build`
-  command.
+  Tags to push on all builds.
 
   Default: `$BUILDKITE_BUILD_NUMBER` (non-removable)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pre-existing ECR repository `my-repo`:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.5:
+      - seek-oss/docker-ecr-publish#v1.1.6:
           ecr-name: my-repo
 ```
 
@@ -22,7 +22,7 @@ An alternate Dockerfile may be specified:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.5:
+      - seek-oss/docker-ecr-publish#v1.1.6:
           dockerfile: path/to/final.Dockerfile
           ecr-name: my-repo
 ```
@@ -35,27 +35,33 @@ environment variable from the pipeline step:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.5:
+      - seek-oss/docker-ecr-publish#v1.1.6:
           args:
             - BUILDKITE_BUILD_NUMBER # propagate environment variable
-            - ENVIRONMENT=prod # explicit value
+          branch-args:
+            - BRANCH_TYPE=branch # explicit value
+          default-args:
+            - BRANCH_TYPE=default # explicit value
           ecr-name: my-repo
 ```
 
-Images built from the default branch are tagged with `latest`. Additional tags
-may be listed, and are split between non-default branches and the default
-branch:
+All images are tagged with their corresponding `$BUILDKITE_BUILD_NUMBER`, and
+images built from the default branch are tagged with `latest`. Additional tags
+may be listed:
 
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.5:
+      - seek-oss/docker-ecr-publish#v1.1.6:
           branch-tags:
-            - $BUILDKITE_BUILD_NUMBER
+            - branch-$BUILDKITE_BUILD_NUMBER
           default-tags:
             # - latest
-            - production
+            - default-$BUILDKITE_BUILD_NUMBER
           ecr-name: my-repo
+          tags:
+            # - $BUILDKITE_BUILD_NUMBER
+            - any-$BUILDKITE_BUILD_NUMBER
 ```
 
 This plugin can be used in combination with the [Create
@@ -67,7 +73,7 @@ steps:
   - plugins:
       - seek-oss/create-ecr#v1.1.2:
           name: my-repo
-      - seek-oss/docker-ecr-publish#v1.1.5:
+      - seek-oss/docker-ecr-publish#v1.1.6:
           ecr-name: my-repo
 ```
 
@@ -87,28 +93,32 @@ steps:
   - plugins:
       - seek-oss/docker-ecr-cache#v1.1.1:
           target: deps
-      - seek-oss/docker-ecr-publish#v1.1.5:
+      - seek-oss/docker-ecr-publish#v1.1.6:
           cache-from: ecr://build-cache/my-org/my-repo
-          name: my-repo
+          ecr-name: my-repo
 ```
 
 ## Configuration
 
-- `args` (optional, array|string):
+- `args` (optional, array|string)
 
-  build-args to pass into docker build.
+  Build args to provide to all builds. These are listed _before_ the
+  branch-specific `branch-args` and `default-args` properties in the resulting
+  `docker build` command.
 
-  Sensitive arguments should be propagated as an environment variable (`MY_ARG`
-  instead of `MY_ARG=blah`), so that they are not checked into your source
-  control and then logged to Buildkite output by this plugin.
+Sensitive arguments should be propagated as an environment variable (`MY_ARG`
+instead of `MY_ARG=blah`), so that they are not checked into your source
+control and then logged to Buildkite output by this plugin.
 
-- `branch-tags` (optional, array)
+- `branch-args` (optional, array|string)
 
-  Tags to push on a non-default branch build.
+  Build args to provide to non-default branch builds.
 
-  Default: none (image is not pushed)
+- `branch-tags` (optional, array|string)
 
-- `cache-from` (optional, array|string):
+  Tags to push on non-default branch builds.
+
+- `cache-from` (optional, array|string)
 
   Images for Docker to use as cache sources, e.g. a base or dependency image.
 
@@ -116,11 +126,15 @@ steps:
   `myregistry.local:5000/testing/test-image`), or the `ecr://my-repo` shorthand
   to point to an ECR repository in the current AWS account.
 
-- `default-tags` (optional, array)
+- `default-args` (optional, array|string)
 
-  Tags to push on a default branch build.
+  Build args to provide to default branch builds.
 
-  Default: `latest` (this cannot be disabled)
+- `default-tags` (optional, array|string)
+
+  Tags to push on default branch builds.
+
+  Default: `latest` (non-removable)
 
 - `dockerfile` (optional, string)
 
@@ -131,6 +145,14 @@ steps:
 - `ecr-name` (required, string)
 
   Name of the ECR repository.
+
+- `tags` (optional, array|string)
+
+  Tags to push on all builds. These are listed _before_ the branch-specific
+  `branch-tags` and `default-tags` properties in the resulting `docker build`
+  command.
+
+  Default: `$BUILDKITE_BUILD_NUMBER` (non-removable)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -110,16 +110,18 @@ reuse a base image across pipeline steps:
 steps:
   - command: npm test
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.1:
+      - seek-oss/docker-ecr-cache#v1.1.2:
+          ecr-name: my-cache
           target: deps
       - docker#v3.0.1:
           volumes:
             - /workdir/node_modules
   - plugins:
-      - seek-oss/docker-ecr-cache#v1.1.1:
+      - seek-oss/docker-ecr-cache#v1.1.2:
+          ecr-name: my-cache
           target: deps
       - seek-oss/docker-ecr-publish#v1.1.6:
-          cache-from: ecr://build-cache/my-org/my-repo
+          cache-from: ecr://my-cache # defaults to latest tag
           ecr-name: my-repo
 ```
 
@@ -148,7 +150,7 @@ steps:
   Images for Docker to use as cache sources, e.g. a base or dependency image.
 
   Use standard Docker image notation (e.g. `debian:jessie`,
-  `myregistry.local:5000/testing/test-image`), or the `ecr://my-repo` shorthand
+  `myregistry.local:5000/testing/test-image`), or the `ecr://cache-repo:tag` shorthand
   to point to an ECR repository in the current AWS account.
 
 - `default-args` (optional, array|string)

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ steps:
   branch-specific `branch-args` and `default-args` properties in the resulting
   `docker build` command.
 
-Sensitive arguments should be propagated as an environment variable (`MY_ARG`
-instead of `MY_ARG=blah`), so that they are not checked into your source
-control and then logged to Buildkite output by this plugin.
+  Sensitive arguments should be propagated as an environment variable (`MY_ARG`
+  instead of `MY_ARG=blah`), so that they are not checked into your source
+  control and then logged to Buildkite output by this plugin.
 
 - `branch-args` (optional, array|string)
 

--- a/hooks/command
+++ b/hooks/command
@@ -12,9 +12,9 @@ get_ecr_url() {
 }
 
 read_build_args() {
-  build_args=()
+  local property="${1}"
 
-  if read_list_property 'ARGS'; then
+  if read_list_property "${property}"; then
     for arg in "${result[@]}"; do
       build_args+=('--build-arg' "${arg}")
     done
@@ -22,15 +22,22 @@ read_build_args() {
 }
 
 read_caches_from() {
-  caches_from=()
-
   if read_list_property 'CACHE_FROM'; then
     for cache in "${result[@]}"; do
       if [[ ${cache} == ecr://* ]]; then
         cache="$(get_ecr_url "${cache:6}")"
       fi
+
       caches_from+=('--cache-from' "${cache}")
     done
+  fi
+}
+
+read_tags() {
+  local property="${1}"
+
+  if read_list_property "${property}"; then
+    tags+=("${result[@]}")
   fi
 }
 
@@ -61,7 +68,7 @@ read_list_property() {
 }
 
 push_tags() {
-  local tags="${1}"
+  local tags=("${1}")
 
   for tag in "${tags[@]}"; do
     echo "Tag: '${tag}'"
@@ -79,21 +86,21 @@ fi
 
 image="$(get_ecr_url "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}")"
 
-read_build_args
+build_args=()
+caches_from=()
+tags=("${BUILDKITE_BUILD_NUMBER}")
 
+read_build_args 'ARGS'
 read_caches_from
+read_tags 'TAGS'
 
 if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
-  build_args+=('--build-arg' 'BRANCH_TYPE=master')
-  tags=('latest')
-  if read_list_property 'DEFAULT_TAGS'; then
-    tags+=("${result[@]}")
-  fi
+  read_build_args 'DEFAULT_ARGS'
+  read_tags 'DEFAULT_TAGS'
+  tags+=('latest')
 else
-  tags=()
-  if read_list_property 'BRANCH_TAGS'; then
-    tags+=("${result[@]}")
-  fi
+  read_build_args 'BRANCH_ARGS'
+  read_tags 'BRANCH_TAGS'
 fi
 
 echo '--- Building Docker image'

--- a/hooks/command
+++ b/hooks/command
@@ -70,7 +70,7 @@ read_list_property() {
 }
 
 push_tags() {
-  local tags=("${1}")
+  local tags=("${@}")
 
   for tag in "${tags[@]}"; do
     echo "Tag: '${tag}'"

--- a/hooks/command
+++ b/hooks/command
@@ -28,6 +28,8 @@ read_caches_from() {
         cache="$(get_ecr_url "${cache:6}")"
       fi
 
+      docker pull "${cache}" || true
+
       caches_from+=('--cache-from' "${cache}")
     done
   fi
@@ -89,6 +91,8 @@ image="$(get_ecr_url "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}")"
 build_args=()
 caches_from=()
 tags=("${BUILDKITE_BUILD_NUMBER}")
+
+echo '--- Reading plugin parameters'
 
 read_build_args 'ARGS'
 read_caches_from

--- a/hooks/command
+++ b/hooks/command
@@ -103,14 +103,14 @@ else
   read_tags 'BRANCH_TAGS'
 fi
 
+echo '--- Logging in to ECR'
+$(aws ecr get-login --no-include-email)
+
 echo '--- Building Docker image'
 echo "Build args: ${build_args[*]}"
 echo "Cache from: ${caches_from[*]}"
 echo "Dockerfile: ${dockerfile}"
 docker build --file "${dockerfile}" --tag "${image}" "${build_args[@]}" "${caches_from[@]}" .
-
-echo '--- Logging in to ECR'
-$(aws ecr get-login --no-include-email)
 
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"

--- a/hooks/command
+++ b/hooks/command
@@ -91,6 +91,11 @@ push_tags() {
   done
 }
 
+echo '--- Logging in to ECR'
+$(aws ecr get-login --no-include-email)
+
+echo '--- Reading plugin parameters'
+
 dockerfile="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
 
 if [[ -z ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME:-} ]]; then
@@ -104,8 +109,6 @@ build_args=()
 caches_from=()
 tags=("${BUILDKITE_BUILD_NUMBER}")
 
-echo '--- Reading plugin parameters'
-
 read_build_args 'ARGS'
 read_caches_from
 read_tags 'TAGS'
@@ -118,9 +121,6 @@ else
   read_build_args 'BRANCH_ARGS'
   read_tags 'BRANCH_TAGS'
 fi
-
-echo '--- Logging in to ECR'
-$(aws ecr get-login --no-include-email)
 
 echo '--- Building Docker image'
 echo "Build args: ${build_args[*]}"

--- a/hooks/command
+++ b/hooks/command
@@ -110,8 +110,7 @@ echo "Dockerfile: ${dockerfile}"
 docker build --file "${dockerfile}" --tag "${image}" "${build_args[@]}" "${caches_from[@]}" .
 
 echo '--- Logging in to ECR'
-readonly login="$(aws ecr get-login --no-include-email)"
-login
+$(aws ecr get-login --no-include-email)
 
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"

--- a/hooks/command
+++ b/hooks/command
@@ -25,7 +25,19 @@ read_caches_from() {
   if read_list_property 'CACHE_FROM'; then
     for cache in "${result[@]}"; do
       if [[ ${cache} == ecr://* ]]; then
-        cache="$(get_ecr_url "${cache:6}")"
+        local image
+        local tag
+
+        image="${cache:6}"
+        tag="${image##*:}"
+
+        if [[ ${image} == "${tag}" ]]; then
+          tag='latest'
+        else
+          image="${image%:*}"
+        fi
+
+        cache="$(get_ecr_url "${image}"):${tag}"
       fi
 
       docker pull "${cache}" || true

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,14 +7,20 @@ configuration:
   properties:
     args:
       type: [array, string]
+    branch-args:
+      type: [array, string]
     branch-tags:
-      type: array
+      type: [array, string]
     cache-from:
       type: [array, string]
+    default-args:
+      type: [array, string]
     default-tags:
-      type: array
+      type: [array, string]
     dockerfile:
       type: string
     ecr-name:
       type: string
+    tags:
+      type: [array, string]
   required: ['ecr-name']


### PR DESCRIPTION
## `args`

- Provide three properties (`args`, `branch-args`, `default-args`) to support
  workflows like GitHub Flow out of the box:

  ```yaml
  steps:
    - plugins:
        - seek-oss/docker-ecr-publish#v1.1.6:
            args: BUILDKITE_BUILD_NUMBER
            branch-args: BRANCH_TYPE=branch
            default-args: BRANCH_TYPE=default
            ecr-name: my-repo
  ```

- Recommend separate steps with differing `branches` for more complex setups:

  ```yaml
  steps:
    - branches: '!dev !prod'
      plugins:
        - seek-oss/docker-ecr-publish#v1.1.6:
            args: BRANCH_TYPE=branch
            ecr-name: my-repo
    - branches: dev
      plugins:
        - seek-oss/docker-ecr-publish#v1.1.6:
            args: BRANCH_TYPE=dev
            ecr-name: my-repo
    - branches: prod
      plugins:
        - seek-oss/docker-ecr-publish#v1.1.6:
            args: BRANCH_TYPE=prod
            ecr-name: my-repo
  ```

- BREAKING CHANGE: drop the hardcoded BRANCH_TYPE=master build arg on default
  branch builds. This was undocumented behaviour, so it won't warrant a major
  version bump. It can be restored with `default-args`:

  ```yaml
  steps:
    - plugins:
        - seek-oss/docker-ecr-publish#v1.1.6:
            default-args: BRANCH_TYPE=master
            ecr-name: my-repo
  ```

## `tags`

- Same as above (`tags`, `branch-tags`, `default-tags`).

- Introduce a hardcoded `$BUILDKITE_BUILD_NUMBER` tag to ensure a push even if
  there are no user-specified tags.

## "List" properties

Allow both array and string values across all `args` and `tags` properties:

```yaml
# array
default-args:
  - BUILD_NUMBER=1

---
# string
default-args: BUILD_NUMBER=1
```
