### PR TITLE
Fix omitted args and cache-from properties

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -126,7 +126,7 @@ echo '--- Building Docker image'
 echo "Build args: ${build_args[*]}"
 echo "Cache from: ${caches_from[*]}"
 echo "Dockerfile: ${dockerfile}"
-docker build --file "${dockerfile}" --tag "${image}" "${build_args[@]}" "${caches_from[@]}" .
+docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} .
 
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"


### PR DESCRIPTION
Bash <4.4 with `set -u` blows up on `"${arr[@]}"` where `arr` is an empty array:

```shell
arr[@]: unbound variable
```

This can be worked around with `${arr[@]+"${arr[@]}"}`.

[Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for-aws) ships with Bash 4.2.