### PR TITLE
fix: Avoid [*]-expanded arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pre-existing ECR repository `my-repo`:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           ecr-name: my-repo
 ```
 
@@ -22,7 +22,7 @@ An alternate Dockerfile may be specified:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           dockerfile: path/to/final.Dockerfile
           ecr-name: my-repo
 ```
@@ -35,7 +35,7 @@ environment variable from the pipeline step:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           args:
             - BUILDKITE_BUILD_NUMBER # propagate environment variable
           branch-args:
@@ -52,7 +52,7 @@ may be listed:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           branch-tags:
             - branch-$BUILDKITE_BUILD_NUMBER
           default-tags:
@@ -71,19 +71,19 @@ with differing `branches`:
 steps:
   - branches: '!dev !prod'
     plugins:
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           args: BRANCH_TYPE=branch
           ecr-name: my-repo
           tags: branch-$BUILDKITE_BUILD_NUMBER
   - branches: dev
     plugins:
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           args: BRANCH_TYPE=dev
           ecr-name: my-repo
           tags: dev-$BUILDKITE_BUILD_NUMBER
   - branches: prod
     plugins:
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           args: BRANCH_TYPE=prod
           ecr-name: my-repo
           tags: prod-$BUILDKITE_BUILD_NUMBER
@@ -98,7 +98,7 @@ steps:
   - plugins:
       - seek-oss/create-ecr#v1.1.2:
           name: my-repo
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           ecr-name: my-repo
 ```
 
@@ -120,7 +120,7 @@ steps:
       - seek-oss/docker-ecr-cache#v1.1.3:
           ecr-name: my-cache
           target: deps
-      - seek-oss/docker-ecr-publish#v1.1.7:
+      - seek-oss/docker-ecr-publish#v1.1.8:
           cache-from: ecr://my-cache # defaults to latest tag
           ecr-name: my-repo
 ```

--- a/hooks/command
+++ b/hooks/command
@@ -123,8 +123,8 @@ else
 fi
 
 echo '--- Building Docker image'
-echo "Build args: ${build_args[*]}"
-echo "Cache from: ${caches_from[*]}"
+echo "Build args: " ${build_args[@]+"${build_args[@]}"}
+echo "Cache from: " ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
 docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} .
 

--- a/hooks/command
+++ b/hooks/command
@@ -123,8 +123,8 @@ else
 fi
 
 echo '--- Building Docker image'
-echo "Build args: " ${build_args[@]+"${build_args[@]}"}
-echo "Cache from: " ${caches_from[@]+"${caches_from[@]}"}
+echo "Build args:" ${build_args[@]+"${build_args[@]}"}
+echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
 docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} .
 


### PR DESCRIPTION
This appears to have compatibility issues with some environments,
leading to the following error message:

```text
line 126: build_args[*]: unbound variable
```