### PR TITLE
Add Remote Context Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ steps:
 
   Tags to push on non-default branch builds.
 
+- `build-context` (optional, string)
+
+  The Docker build context. Valid values are as per the [API](https://docs.docker.com/engine/reference/commandline/build/#extended-description)
+
+  Default: `.`
+
 - `cache-from` (optional, array|string)
 
   Images for Docker to use as cache sources, e.g. a base or dependency image.

--- a/hooks/command
+++ b/hooks/command
@@ -126,7 +126,7 @@ echo '--- Building Docker image'
 echo "Build args:" ${build_args[@]+"${build_args[@]}"}
 echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
-docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} .
+docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}
 
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"

--- a/hooks/command
+++ b/hooks/command
@@ -97,6 +97,7 @@ $(aws ecr get-login --no-include-email)
 echo '--- Reading plugin parameters'
 
 dockerfile="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
+build_context="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}"
 
 if [[ -z ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME:-} ]]; then
   echo "'ecr-name' property is required"
@@ -126,7 +127,8 @@ echo '--- Building Docker image'
 echo "Build args:" ${build_args[@]+"${build_args[@]}"}
 echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
-docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}
+echo "Build context: ${build_context}"
+docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} "${build_context}"
 
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,6 +5,8 @@ requirements:
   - docker
 configuration:
   properties:
+    build-context:
+      type: string
     args:
       type: [array, string]
     branch-args:


### PR DESCRIPTION
Allows defining a [remote Docker `build` context](https://docs.docker.com/engine/reference/commandline/build/#extended-description), rather than just relying on local `Dockerfile`.

Defaults to the latter, so it's not a breaking API change