### PR TITLE
add target parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ steps:
 
   Default: `$BUILDKITE_BUILD_NUMBER` (non-removable)
 
+- `target` (optional, string)
+
+  When building a Dockerfile with multiple build stages, target can be used to specify an intermediate build stage by name as the final stage for the resulting image. This corresponds to the Docker CLI `--target` parameter.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -98,6 +98,7 @@ echo '--- Reading plugin parameters'
 
 dockerfile="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
 build_context="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}"
+target="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_TARGET:-.}"
 
 if [[ -z ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME:-} ]]; then
   echo "'ecr-name' property is required"
@@ -123,12 +124,19 @@ else
   read_tags 'BRANCH_TAGS'
 fi
 
+# set target arg if target was specified
+target_arg=""
+if [[ -n ${target} ]]; then
+  target_arg="--target ${target}"
+fi
+
 echo '--- Building Docker image'
 echo "Build args:" ${build_args[@]+"${build_args[@]}"}
 echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
 echo "Build context: ${build_context}"
-docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} "${build_context}"
+echo "Target: ${target}"
+docker build --file "${dockerfile}" --tag "${image}" ${build_args[@]+"${build_args[@]}"} ${caches_from[@]+"${caches_from[@]}"} ${target_arg} "${build_context}"
 
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,4 +25,6 @@ configuration:
       type: string
     tags:
       type: [array, string]
+    target:
+      type: string
   required: ['ecr-name']


### PR DESCRIPTION
When you have a multi-stage docker file you sometimes want to build an image of an intermediate step like a builder. This PR adds supports for the docker target parameter