### PR TITLE
Target ECR registry by Account ID and Region

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ steps:
           ecr-name: my-repo
 ```
 
+We can target registries in other accounts and regions, provided the current IAM user/role has the ability to auth against said account/registry:
+
+```yaml
+steps:
+  - plugins:
+      - seek-oss/docker-ecr-publish#v1.4.0:
+          account_id: 12345678910
+          region: eu-west-1
+          ecr-name: my-repo
+```
+
 ## Configuration
 
 - `args` (optional, array|string)
@@ -195,6 +206,14 @@ steps:
 - `ecr-name` (required, string)
 
   Name of the ECR repository.
+
+- `account_id` (optional, string)
+
+  Account ID for ECR registry, defaults to output of `aws sts get-caller-identity` e.g. current account ID.
+
+- `region` (optional, string)
+
+  Region the ECR registry is in, defaults to `$AWS_DEFAULT_REGION` and then `aws configure get region` if not set.
 
 - `tags` (optional, array|string)
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ We can target registries in other accounts and regions, provided the current IAM
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v1.4.0:
+      - seek-oss/docker-ecr-publish#v1.5.0:
           account_id: 12345678910
           region: eu-west-1
           ecr-name: my-repo

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ We can target registries in other accounts and regions, provided the current IAM
 steps:
   - plugins:
       - seek-oss/docker-ecr-publish#v1.5.0:
-          account_id: 12345678910
+          account_id: '12345678910'
           region: eu-west-1
           ecr-name: my-repo
 ```

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ steps:
 
 - `region` (optional, string)
 
-  Region the ECR registry is in, defaults to `$AWS_DEFAULT_REGION` and then `aws configure get region` if not set.
+  Region the ECR registry is in, defaults to `$AWS_DEFAULT_REGION` and then `eu-west-1` if not set.
 
 - `tags` (optional, array|string)
 

--- a/hooks/command
+++ b/hooks/command
@@ -2,11 +2,17 @@
 
 set -euo pipefail
 
+set -x
+
 get_ecr_url() {
   local repository_name="${1}"
+  local registry_id="${2}"
+  local region="${3}"
 
   aws ecr describe-repositories \
+    --region "${region}" \
     --repository-names "${repository_name}" \
+    --registry-id "${registry_id}" \
     --output text \
     --query 'repositories[0].repositoryUri'
 }
@@ -91,8 +97,33 @@ push_tags() {
   done
 }
 
+ecr_login() {
+  local region="${1}"
+  local account_id="${2}"
+
+  aws ecr get-login-password \
+    --region "${region}" \
+    | docker login \
+    --username AWS \
+    --password-stdin "${account_id}".dkr.ecr."${region}".amazonaws.com
+}
+
 echo '--- Logging in to ECR'
-$(aws ecr get-login --no-include-email)
+
+if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_REGION:-} ]]; then
+  region="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_REGION}"
+else
+  region="${AWS_DEFAULT_REGION:-$(aws configure get region)}"
+fi
+
+
+if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ACCOUNT_ID:-} ]]; then
+  account_id="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ACCOUNT_ID}"
+else
+  account_id="$(aws sts get-caller-identity --output text | cut -f1)"
+fi
+
+ecr_login "$region" "$account_id"
 
 echo '--- Reading plugin parameters'
 
@@ -105,7 +136,7 @@ if [[ -z ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME:-} ]]; then
   exit 1
 fi
 
-image="$(get_ecr_url "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}")"
+image="$(get_ecr_url "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}" "${account_id}" "${region}")"
 
 build_args=()
 caches_from=()

--- a/hooks/command
+++ b/hooks/command
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-set -x
-
 get_ecr_url() {
   local repository_name="${1}"
   local registry_id="${2}"
@@ -113,7 +111,7 @@ echo '--- Logging in to ECR'
 if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_REGION:-} ]]; then
   region="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_REGION}"
 else
-  region="${AWS_DEFAULT_REGION:-$(aws configure get region)}"
+  region="${AWS_DEFAULT_REGION:-eu-west-1}"
 fi
 
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,7 +25,7 @@ configuration:
       type: string
     ecr-name:
       type: string
-    account_id:
+    account-id:
       type: string
     region:
       type: string

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,6 +25,10 @@ configuration:
       type: string
     ecr-name:
       type: string
+    account_id:
+      type: string
+    region:
+      type: string
     tags:
       type: [array, string]
     target:


### PR DESCRIPTION
## Background

We're looking to build and push our Docker images to the account where our ECR repositories reside, which are then shared across multiple accounts.

The region we use is the same across all accounts however where we build images is different to where we store them.

Ideally I wouldn't be touching on the region however it's required by [get-login-password](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html#examples).

## Changes

* Now using `get-login-password` command, due to `get-login` being deprecated
* Ability to target registries by Account ID
* Ability to set region for registry that is being targeted

## Example

```
steps:
  - label: "Building and pushing image to ECR :docker:"
    plugins:
      - henrycook/docker-ecr-publish#v1.5.0:
          ecr-name: my-repo
          account_id: 12345678910
          region: eu-west-1
          tags: ${BUILDKITE_COMMIT}
```

## Notes

This may introduce a breaking change in regards to the `region` changes as I couldn't think of a sane way to handle this. Open to ideas on potential nicer ways to handle this.

If the `get-login` command wasn't being deprecated we wouldn't have to amend the region, however it seems this has been requested already (https://github.com/seek-oss/docker-ecr-publish-buildkite-plugin/issues/14).