### PR TITLE
Fix cache-from with ecr shorthand

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -41,7 +41,7 @@ read_caches_from() {
           image="${image%:*}"
         fi
 
-        cache="$(get_ecr_url "${image}"):${tag}"
+        cache="$(get_ecr_url "${image}" "${account_id}" "${region}"):${tag}"
       fi
 
       docker pull "${cache}" || true


### PR DESCRIPTION
Fix a regression introduced by #20.

This will use an ECR repository in the same account and region as configured for this plugin.
