### PR TITLE
Add option to save image digest as metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,9 @@ steps:
 
 - `save-digest-as-metadata` (optional, string)
 
-  Allows you specify if the digest of the docker image should be saved to a buildkite metadata variable.
-  Please specify the name of the metadata variable e.g. `save-digest-as-metadata: runtime-image-digest`
+  Specify a Buildkite metadata variable to save the Docker image digest to,
+  e.g. `save-digest-as-metadata: runtime-image-digest`.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ steps:
 
   When building a Dockerfile with multiple build stages, target can be used to specify an intermediate build stage by name as the final stage for the resulting image. This corresponds to the Docker CLI `--target` parameter.
 
+- `save-digest-as-metadata` (optional, string)
+
+  Allows you specify if the digest of the docker image should be saved to a buildkite metadata variable.
+  Please specify the name of the metadata variable e.g. `save-digest-as-metadata: runtime-image-digest`
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -182,7 +182,7 @@ docker build \
 
 save_digest_as_metadata="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_SAVE_DIGEST_AS_METADATA:-}"
 if [[ -n ${save_digest_as_metadata} ]]; then
-  echo "--- Saving digest of image to buildkite metadata: ${save_digest_as_metadata}"
+  echo "--- Saving Docker image digest to Buildkite metadata: ${save_digest_as_metadata}"
   image_digest="$(docker images --no-trunc --quiet "${image}:latest")"
 
   buildkite-agent meta-data set "${save_digest_as_metadata}" "${image_digest}"

--- a/hooks/command
+++ b/hooks/command
@@ -180,5 +180,13 @@ docker build \
   ${target_arg} \
   "${build_context}"
 
+save_digest_as_metadata="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_SAVE_DIGEST_AS_METADATA:-}"
+if [[ -n ${save_digest_as_metadata} ]]; then
+  echo "--- Saving digest of image to buildkite metadata: ${save_digest_as_metadata}"
+  image_digest="$(docker images --no-trunc --quiet "${image}:latest")"
+
+  buildkite-agent meta-data set "${save_digest_as_metadata}" "${image_digest}"
+fi
+
 echo '--- Pushing Docker image'
 push_tags "${tags[@]}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,4 +35,6 @@ configuration:
       type: string
     add-latest-tag:
       type: boolean
+    save-digest-as-metadata:
+      type: string
   required: ['ecr-name']


### PR DESCRIPTION
This PR allows to save the digest of the generated image to the Buildkite metadata. This is handy when you need the digest of the image later one in the pipeline (e.g. to deploy the image). 

We are building multiple images in our Buildkite pipelines so I need a way to specify the name of the metadata variable. 

This change is backwards compatible; nothing changes if you don't specify `save-digest-as-metadata`.