### PR TITLE
Parallelize push; speedup cache & login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Docker ECR Publish Buildkite Plugin
 
-[![GitHub Release](https://img.shields.io/github/release/seek-oss/docker-ecr-publish-buildkite-plugin.svg)](https://github.com/seek-oss/docker-ecr-publish-buildkite-plugin/releases)
+[![GitHub Release](https://img.shields.io/github/release/ROKT/docker-ecr-publish-buildkite-plugin.svg)](https://github.com/ROKT/docker-ecr-publish-buildkite-plugin/releases)
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to build, tag, and push Docker images to Amazon ECR.
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to build, tag, and push Docker images to Amazon ECR. Based on [ROKT/docker-ecr-publish-buildkite-plugin](https://github.com/ROKT/docker-ecr-publish-buildkite-plugin) which is no longer supported.
 
 ## Example
 
@@ -11,7 +11,7 @@ The following pipeline builds the default `./Dockerfile` and pushes it to a pre-
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           ecr-name: my-repo
 ```
 
@@ -20,7 +20,7 @@ An alternate Dockerfile may be specified:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           dockerfile: path/to/final.Dockerfile
           ecr-name: my-repo
 ```
@@ -32,7 +32,7 @@ or without one to propagate an environment variable from the pipeline step:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           args:
             - BUILDKITE_BUILD_NUMBER # propagate environment variable
           branch-args:
@@ -50,7 +50,7 @@ Additional tags may be listed:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           branch-tags:
             - branch-$BUILDKITE_BUILD_NUMBER
           default-tags:
@@ -68,7 +68,7 @@ you can disable the `latest` tag with the `add-latest-tag` property:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           add-latest-tag: false
           ecr-name: my-repo
 ```
@@ -79,19 +79,19 @@ More complex branch workflows can be achieved by using multiple pipeline steps w
 steps:
   - branches: '!dev !prod'
     plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           args: BRANCH_TYPE=branch
           ecr-name: my-repo
           tags: branch-$BUILDKITE_BUILD_NUMBER
   - branches: dev
     plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           args: BRANCH_TYPE=dev
           ecr-name: my-repo
           tags: dev-$BUILDKITE_BUILD_NUMBER
   - branches: prod
     plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           args: BRANCH_TYPE=prod
           ecr-name: my-repo
           tags: prod-$BUILDKITE_BUILD_NUMBER
@@ -105,39 +105,39 @@ steps:
     env:
       DOCKER_BUILDKIT: '1'
     plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           additional-build-args: '--progress=plain --ssh= default=\$SSH_AUTH_SOCK'
       - docker#v3.5.0
 ```
 
-This plugin can be used in combination with the [Create ECR](https://github.com/seek-oss/create-ecr-buildkite-plugin) plugin to fully manage an ECR application repository within one pipeline step:
+This plugin can be used in combination with the [Create ECR](https://github.com/ROKT/create-ecr-buildkite-plugin) plugin to fully manage an ECR application repository within one pipeline step:
 
 ```yaml
 steps:
   - plugins:
-      - seek-oss/create-ecr#v1.1.2:
+      - ROKT/create-ecr#v1.1.2:
           name: my-repo
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           ecr-name: my-repo
 ```
 
-This plugin can be used in combination with the [Docker ECR Cache](https://github.com/seek-oss/docker-ecr-cache-buildkite-plugin) plugin to reuse a base image across pipeline steps:
+This plugin can be used in combination with the [Docker ECR Cache](https://github.com/ROKT/docker-ecr-cache-buildkite-plugin) plugin to reuse a base image across pipeline steps:
 
 ```yaml
 steps:
   - command: npm test
     plugins:
-      - seek-oss/docker-ecr-cache#v1.7.0:
+      - ROKT/docker-ecr-cache#v1.7.0:
           ecr-name: my-cache
           target: deps
       - docker#v3.5.0:
           volumes:
             - /workdir/node_modules
   - plugins:
-      - seek-oss/docker-ecr-cache#v1.7.0:
+      - ROKT/docker-ecr-cache#v1.7.0:
           ecr-name: my-cache
           target: deps
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           cache-from: ecr://my-cache # defaults to latest tag
           ecr-name: my-repo
 ```
@@ -147,7 +147,7 @@ We can target registries in other accounts and region(s), provided the current I
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v2.3.0:
+      - ROKT/docker-ecr-publish#v2.4.0:
           account_id: '12345678910'
           region: eu-west-1
           ecr-name: my-repo
@@ -156,7 +156,7 @@ steps:
 ```yaml
 steps:
   - plugins:
-      - seek-oss/docker-ecr-publish#v2.1.0:
+      - ROKT/docker-ecr-publish#v2.1.0:
           account_id: '12345678910'
           regions:
             - eu-west-1

--- a/hooks/command
+++ b/hooks/command
@@ -27,6 +27,9 @@ read_build_args() {
 
 read_caches_from() {
   if read_list_property 'CACHE_FROM'; then
+    CURRENT_LOGGED_IN_REGION=""
+    CURRENT_LOGGED_IN_ACCOUNT=""
+
     for cache in "${result[@]}"; do
       if [[ ${cache} == ecr://* ]]; then
         local image
@@ -43,14 +46,19 @@ read_caches_from() {
 
         for region in "${regions[@]}"; do
 
-          echo "Logging in to ECR, region: ${region}"
-          ecr_login "$region" "$account_id"
+          if ! { [ "${CURRENT_LOGGED_IN_REGION}" = "${region}" ] && [ "${CURRENT_LOGGED_IN_ACCOUNT}" = "${account_id}" ]; }; then
+            echo "Logging in to ECR, region: ${region}"
+            ecr_login "$region" "$account_id"
+            CURRENT_LOGGED_IN_REGION="${region}"
+            CURRENT_LOGGED_IN_ACCOUNT="${account_id}"
+          fi
 
           cache="$(get_ecr_url "${image}" "${account_id}" "${region}"):${tag}"
 
-          docker pull "${cache}" || true
-          caches_from+=('--cache-from' "${cache}")
-
+          if docker pull "${cache}"; then
+            caches_from+=('--cache-from' "${cache}")
+            break
+          fi
         done
       fi
 
@@ -111,6 +119,7 @@ push_tags() {
 
   for region in "${regions[@]}"; do
 
+    local -A push_tasks
     echo "Logging in to ECR, region: ${region}"
     ecr_login "$region" "$account_id"
 
@@ -119,8 +128,20 @@ push_tags() {
     for tag in "${tags[@]}"; do
       echo "Tag: '${tag}'"
       docker tag "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}" "${image}:${tag}"
-      docker push "${image}:${tag}"
+      docker push "${image}:${tag}" &
+      local backgrounded_pid=$!
+      push_tasks[${backgrounded_pid}]="${region}-${image}:${tag}"
     done
+    # Wait for completion
+    for pid in "${!push_tasks[@]}"; do
+      if wait "$pid"; then
+        echo "[${push_tasks[${pid}]}] Push task succeeded"
+      else
+        echo "[${push_tasks[${pid}]}] Push task failed"
+        exit 1
+      fi
+    done
+    unset push_tasks
 
   done
 }


### PR DESCRIPTION
This speeds up pipelines run by

Skip downloading cache layers from other regions if we successfully pull it
Pushing images to multiple regions in parallel

A port of this [PR](https://github.com/seek-oss/docker-ecr-publish-buildkite-plugin/pull/27) from the original repo