### PR TITLE
Add options to select build driver & cache exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,26 @@ steps:
   Specify a Buildkite metadata variable to save the Docker image digest to,
   e.g. `save-digest-as-metadata: runtime-image-digest`.
 
+- `driver` (optional, string, one of `buildkit`, `legacy`)
+  > Default value `legacy`
+
+  Specify a Buildkite driver to use for building the image,
+  e.g. `driver: buildkit`.
+
+- `progress-output` (optional, string, one of `plain`, `tty`, `auto`)
+  > Only takes effect if `driver: buildkit`  
+  > Default value `plain`
+
+  Specify the progress output format,
+  e.g. `progress-output: tty`.
+
+- `disable-cache-metadata` (optional, string)
+  > Only takes effect if `driver: buildkit`  
+  > Default `false`
+
+  Recommendation is to keep it `false`. Docker buildkit uses cached layers from a previously built image and listed in `cache-from` property. This greatly reduces time taken to build an image. Turning cache metadata off might significantly increase build time.
+  e.g. `disable-cache-metadata: true`.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -25,6 +25,52 @@ read_build_args() {
   fi
 }
 
+read_build_driver() { 
+  # read driver
+  local property="DRIVER"
+  enable_buildkit=0 # set default
+  if read_list_property "${property}"; then
+    for arg in "${result[@]}"; do
+      if [[ "$arg" == "buildkit" ]]; then
+        echo "Chosing driver: buildkit"
+        enable_buildkit=1
+
+        # read cache metadata settings if driver=buildkit
+        property="DISABLE_CACHE_METADATA"
+        enable_cache_metadata=1
+        if read_list_property "${property}"; then
+          for arg in "${result[@]}"; do
+            if [[ "$arg" == "true" ]]; then
+              echo "Disabling metadata"
+              enable_cache_metadata=0
+              break
+            fi
+          done
+        fi
+        
+        build_args+=('--build-arg' "BUILDKIT_INLINE_CACHE=${enable_cache_metadata}")
+
+        # read progress output if driver=buildkit
+        property="PROGRESS_OUTPUT"
+        progress_output="plain" # set default
+        if read_list_property "${property}"; then
+          for arg in "${result[@]}"; do
+            echo "Setting progress output to: ${arg}"
+            progress_output="${arg}"
+            break
+          done
+        fi
+
+        build_args+=('--progress' "${progress_output}")
+
+      else 
+        echo "Chosing driver: legacy"
+        enable_buildkit=0
+      fi
+    done
+  fi
+}
+
 read_caches_from() {
   if read_list_property 'CACHE_FROM'; then
     CURRENT_LOGGED_IN_REGION=""
@@ -168,12 +214,14 @@ dockerfile="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
 build_context="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}"
 target="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_TARGET:-}"
 
+# by default disable buildkit
+enable_buildkit=0
 build_args=()
 caches_from=()
 tags=("${BUILDKITE_BUILD_NUMBER}")
 
 regions=()
-
+read_build_driver
 read_build_args 'ARGS'
 read_tags 'TAGS'
 
@@ -209,12 +257,14 @@ echo '--- Building Docker image'
 if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS:-} ]]; then
   echo "Additional build args: ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS}"
 fi
+echo "Buildkit:" ${enable_buildkit}
 echo "Build args:" ${build_args[@]+"${build_args[@]}"}
 echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
 echo "Build context: ${build_context}"
 echo "Target: ${target}"
-docker build \
+DOCKER_BUILDKIT=${enable_buildkit} \
+  docker build \
   --file "${dockerfile}" \
   --tag "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}" \
   ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS:-} \

--- a/plugin.yml
+++ b/plugin.yml
@@ -39,6 +39,14 @@ configuration:
       type: boolean
     save-digest-as-metadata:
       type: string
+    driver:
+      type: string
+      enum: ["legacy", "buildkit"]
+    disable-cache-metadata:
+      type: boolean
+    progress-output:
+      type: string
+      enum: ["plain", "tty", "auto"]
   required: ['ecr-name']
   not:
     required: ['region', 'regions']


### PR DESCRIPTION
At Rokt (www.rokt.com), we added a few options to improve our experience with the plugin. Sending the changes upstream in case this can be added to the plugin for others to take the benefit.

### What has changed ###

Added properties to select build driver and to export cache metadata, so that pulled image caches can be used in a different machine.

### New Options ###

- `driver` (optional, string, one of `buildkit`, `legacy`)
  > Default value `legacy`
  Specify a Buildkite driver to use for building the image,
  e.g. `driver: buildkit`.

- `progress-output` (optional, string, one of `plain`, `tty`, `auto`)
  > Only takes effect if `driver: buildkit`  
  > Default value `plain`
  Specify the progress output format,
  e.g. `progress-output: tty`.

- `disable-cache-metadata` (optional, string)
  > Only takes effect if `driver: buildkit`  
  > Default `false`
  The recommendation is to keep it `false`. Docker buildkit uses cached layers from a previously built image and is listed in `cache-from` property. This greatly reduces the time taken to build an image. Turning cache metadata off might significantly increase build time.
  e.g. `disable-cache-metadata: true`.
